### PR TITLE
Link to the individual guides right in the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,11 @@
 
 A Ruby implementation of [GraphQL](http://graphql.org/).
 
- - [Introduction](https://github.com/rmosolgo/graphql-ruby/blob/master/guides/introduction.md)
+ - Guides
+     - [Introduction](https://github.com/rmosolgo/graphql-ruby/blob/master/guides/introduction.md)
+     - [Defining Your Schema](https://github.com/rmosolgo/graphql-ruby/blob/master/guides/defining_your_schema.md)
+     - [Executing Queries](https://github.com/rmosolgo/graphql-ruby/blob/master/guides/executing_queries.md)
+
  - [API Documentation](http://www.rubydoc.info/github/rmosolgo/graphql-ruby)
 
 ## Installation


### PR DESCRIPTION
Having them listed out there right at the top of the README I think
improves discoverability. Previously, it just link directly to the
introduction, which if you didn't read all the way to the bottom, you
might not realize that more guides exist.
